### PR TITLE
refactor: migrate to event listeners to resolve deprecations

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -9,17 +9,15 @@ declare(strict_types=1);
 
 namespace OCA\JSLoader\AppInfo;
 
-use OC\Security\CSP\ContentSecurityPolicy;
-use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+use OCA\JSLoader\Listeners\AddContentSecurityPolicyListener;
+use OCA\JSLoader\Listeners\BeforeTemplateRenderedListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\IAppConfig;
-use OCP\IURLGenerator;
-use OCP\Security\IContentSecurityPolicyManager;
-use OCP\Server;
-use OCP\Util;
+use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'jsloader';
@@ -29,38 +27,12 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
-		// nothing to do here
+		$context->registerEventListener(AddContentSecurityPolicyEvent::class, AddContentSecurityPolicyListener::class);
+		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+		$context->registerEventListener(BeforeLoginTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {
-		$appConfig = Server::get(IAppConfig::class);
-		$urlGenerator = Server::get(IURLGenerator::class);
-		$contentSecurityPolicyManager = Server::get(IContentSecurityPolicyManager::class);
-		$contentSecurityPolicyNonceManager = Server::get(ContentSecurityPolicyNonceManager::class);
-
-		$snippet = $appConfig->getValueString(self::APP_ID, 'snippet', '');
-		if ($snippet !== '') {
-			$linkToJs = $urlGenerator->linkToRoute('jsloader.JS.script', [
-				'v' => $appConfig->getValueString(self::APP_ID, 'cachebuster', '0'),
-			]);
-
-			Util::addHeader(
-				'script',
-				[
-					'src' => $linkToJs,
-					'nonce' => $contentSecurityPolicyNonceManager->getNonce()
-				], ''
-			);
-
-			// whitelist the URL to allow loading JS from this external domain
-			$url = $appConfig->getValueString(self::APP_ID, 'url');
-			if ($url !== '') {
-				$policy = new ContentSecurityPolicy();
-				$policy->addAllowedScriptDomain($url);
-				$policy->addAllowedImageDomain($url);
-				$policy->addAllowedConnectDomain($url);
-				$contentSecurityPolicyManager->addDefaultPolicy($policy);
-			}
-		}
+		// nop
 	}
 }

--- a/lib/Listeners/AddContentSecurityPolicyListener.php
+++ b/lib/Listeners/AddContentSecurityPolicyListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\JSLoader\Listeners;
+
+use OCA\JSLoader\AppInfo\Application;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+
+/**
+ * Listener to add the configured domain to the Content Security Policy to allow loading JS from there.
+ *
+ * @template-implements IEventListener<AddContentSecurityPolicyEvent>
+ */
+class AddContentSecurityPolicyListener implements IEventListener {
+
+	public function __construct(
+		private readonly \OCP\IAppConfig $appConfig,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof AddContentSecurityPolicyEvent) {
+			return;
+		}
+
+		// whitelist the URL to allow loading JS from this external domain
+		$url = $this->appConfig->getValueString(Application::APP_ID, 'url');
+		if ($url !== '') {
+			$policy = new ContentSecurityPolicy();
+			$policy->addAllowedScriptDomain($url);
+			$policy->addAllowedImageDomain($url);
+			$policy->addAllowedConnectDomain($url);
+			$event->addPolicy($policy);
+		}
+	}
+}

--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\JSLoader\Listeners;
+
+use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+use OCA\JSLoader\AppInfo\Application;
+use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\Util;
+
+/**
+ * Listener to add the configured domain to the Content Security Policy to allow loading JS from there.
+ *
+ * @template-implements IEventListener<BeforeTemplateRenderedEvent|BeforeLoginTemplateRenderedEvent>
+ */
+class BeforeTemplateRenderedListener implements IEventListener {
+
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly ContentSecurityPolicyNonceManager $contentSecurityPolicyNonceManager,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforeTemplateRenderedEvent) && !($event instanceof BeforeLoginTemplateRenderedEvent)) {
+			return;
+		}
+
+		$snippet = $this->appConfig->getValueString(Application::APP_ID, 'snippet', '');
+		if ($snippet === '') {
+			return;
+		}
+
+		$linkToJs = $this->urlGenerator->linkToRoute('jsloader.JS.script', [
+			'v' => $this->appConfig->getValueString(Application::APP_ID, 'cachebuster', '0'),
+		]);
+
+		Util::addHeader(
+			'script',
+			[
+				'src' => $linkToJs,
+				'nonce' => $this->contentSecurityPolicyNonceManager->getNonce()
+			], ''
+		);
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="4"
+    errorLevel="1"
     errorBaseline="tests/psalm-baseline.xml"
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
@@ -19,6 +19,7 @@
     <extraFiles>
         <directory name="vendor" />
     </extraFiles>
-    <issueHandlers>
-    </issueHandlers>
+    <stubs>
+        <file name="tests/stubs/oc_security_csp_ContentSecurityPolicyNonceManager.php" />
+    </stubs>
 </psalm>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,9 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
-  <file src="lib/AppInfo/Application.php">
-    <UndefinedClass>
-      <code><![CDATA[ContentSecurityPolicy]]></code>
-      <code><![CDATA[ContentSecurityPolicyNonceManager]]></code>
-    </UndefinedClass>
-  </file>
-</files>
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0"/>

--- a/tests/stubs/oc_security_csp_ContentSecurityPolicyNonceManager.php
+++ b/tests/stubs/oc_security_csp_ContentSecurityPolicyNonceManager.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Security\CSP;
+
+/**
+ * @package OC\Security\CSP
+ */
+class ContentSecurityPolicyNonceManager {
+
+	/**
+	 * Returns the current CSP nonce
+	 */
+	public function getNonce(): string {
+	}
+	/**
+	 * Check if the browser supports CSP v3
+	 */
+	public function browserSupportsCspV3(): bool {
+	}
+}


### PR DESCRIPTION
- [x] :warning: this is based on #47 

`OCP\Security\IContentSecurityPolicyManager` is deprecated, thus we have to migrate to the listeners approach. So this migrates both the CSP handling and the scripts handling to the listeners.
Also added stubs instead of baseline entries.