### PR TITLE
fix: Fixed custom script not being loaded on two factor pages

### DIFF
--- a/lib/Controller/JSController.php
+++ b/lib/Controller/JSController.php
@@ -28,6 +28,7 @@ class JSController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 * @PublicPage
+	 * @NoTwoFactorRequired
 	 *
 	 * @return Response
 	 */


### PR DESCRIPTION
Hey there,

i have noticed that custom scrips using this app are not loaded on the two factor pages as request to the controller providing the script gets blocked by the two factor app. In this pull request i just added the annotation which allows the controller being accessible in the two factor state.

Thank you for reading and i hope you will merge it so i no longer need to modify it locally myself 🙏 